### PR TITLE
Feat/env cookie and read warning

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ import { Command } from "commander";
 import kleur from "kleur";
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { extractCookies, parseCookieString, type CookieSource } from "./lib/cookies.js";
 import { XhsClient, XhsApiError } from "./lib/client.js";
 import { analyzeViral, formatViralAnalysis } from "./lib/analyze.js";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,9 +27,9 @@
 
 import { Command } from "commander";
 import kleur from "kleur";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { extractCookies, parseCookieString, type CookieSource } from "./lib/cookies.js";
 import { XhsClient, XhsApiError } from "./lib/client.js";
 import { analyzeViral, formatViralAnalysis } from "./lib/analyze.js";
@@ -76,6 +76,32 @@ function addJsonOption(cmd: Command): Command {
   return cmd.option("--json", "Output as JSON");
 }
 
+function loadEnvFile(): void {
+  // Walk up from cwd looking for .env (stops at filesystem root)
+  let dir = process.cwd();
+  while (true) {
+    const envPath = join(dir, ".env");
+    if (existsSync(envPath)) {
+      const lines = readFileSync(envPath, "utf-8").split(/\r?\n/);
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const eqIdx = trimmed.indexOf("=");
+        if (eqIdx === -1) continue;
+        const key = trimmed.slice(0, eqIdx).trim();
+        const value = trimmed.slice(eqIdx + 1).trim();
+        if (key && !(key in process.env)) {
+          process.env[key] = value;
+        }
+      }
+      return;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return; // reached root
+    dir = parent;
+  }
+}
+
 async function getClient(cookieSource: string, chromeProfile?: string, cookieString?: string): Promise<XhsClient> {
   if (cookieString) {
     const cookies = parseCookieString(cookieString);
@@ -89,6 +115,17 @@ async function getClient(cookieSource: string, chromeProfile?: string, cookieStr
     console.error(kleur.dim("Using manual cookie string."));
     return new XhsClient(cookies);
   }
+
+  // Try env vars (from .env or shell environment)
+  loadEnvFile();
+  const envA1 = process.env.XHS_COOKIE_A1;
+  const envSession = process.env.XHS_COOKIE_WEB_SESSION;
+  if (envA1 && envSession) {
+    const cookies = parseCookieString(`a1=${envA1}; web_session=${envSession}`);
+    console.error(kleur.dim("Using cookies from environment variables (XHS_COOKIE_A1 + XHS_COOKIE_WEB_SESSION)."));
+    return new XhsClient(cookies);
+  }
+
   const cookies = await extractCookies(cookieSource as CookieSource, chromeProfile);
   return new XhsClient(cookies);
 }
@@ -220,6 +257,16 @@ readCmd.action(async (url, opts) => {
       }
     } else {
       result = await client.getNoteFromHtml(noteId, xsecToken ?? "");
+    }
+
+    // Warn when result is empty and xsec_token was missing
+    const isEmpty = !result || (typeof result === "object" && Object.keys(result as object).length === 0);
+    if (isEmpty && !xsecToken) {
+      console.error(kleur.yellow(
+        "Note returned empty. This usually means the request needs an xsec_token.\n" +
+        "Tip: use a full URL with xsec_token from search results or the browser, e.g.:\n" +
+        `  redbook read "https://www.xiaohongshu.com/explore/${noteId}?xsec_token=TOKEN"`
+      ));
     }
 
     if (opts.json) {


### PR DESCRIPTION
我遇到的问题如下：
                                                                                                                                                                                                   
问题 1：Windows 上 Cookie 自动提取全军覆没                                                                                                                                                                                                                                                                                                                                                                                    
  在 Windows 11 + Chrome 127+ 环境下，redbook whoami 的 cookie 提取链路全部失败：                                                                                                                               
  
  1. 标准读取：Chrome 的 App-Bound Encryption 加密了 cookie 数据库，@steipete/sweet-cookie 读不到 XHS session
  2. 文件复制 fallback：cookie DB 文件被 Chrome 进程锁定（EBUSY: resource busy or locked）
  3. CDP fallback：启动 headless Chrome 尝试通过 DevTools 协议读取，但 Network.getAllCookies 方法不存在（疑似 Chrome 版本差异）
  4. 临时 profile 复制：复制用户 profile 到 temp 目录也失败

  最终只能靠 --cookie-string "a1=xxx; web_session=xxx" 手动传入，每次都要复制一长串。

问题 2：read 命令静默失败

  redbook read <noteId> 不带 xsec_token 时，返回空 JSON {}，人类可读模式显示 (no title) by @unknown，没有任何提示告诉用户哪里出了问题或怎么修。

所以做了如下修改：
- **`.env` 自动读 cookie**：未传 `--cookie-string` 时，自动从环境变量 `XHS_COOKIE_A1` + `XHS_COOKIE_WEB_SESSION` 读取（支持 `.env` 文件，从 cwd 向上查找）。Windows 上 Chrome 127+ 的 App-Bound Encryption会导致自动提取 cookie 失败，这个改动提供了一个可靠的替代方案。
  - **`read` 空结果提示**：当 `read` 返回空且缺少 `xsec_token` 时，输出黄色警告并给出正确的 URL 格式示例。

  ## Cookie 优先级

  `--cookie-string` > 环境变量（`.env` 或 shell）> 浏览器提取

  ## 测试

  - `redbook whoami`：`.env` 有 cookie 时自动连接成功
  - `redbook read <noteId>`：无 xsec_token 时显示警告
  - `--cookie-string` 仍优先于环境变量
  - `tsc` 编译通过